### PR TITLE
Added Platform API

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import { render } from './renderer/render';
+import Platform from './utils/platform';
 
 /**
  * Component name (input to createElement function call after transpilation with Babel)
@@ -32,5 +33,6 @@ export {
   Table,
   Header,
   Footer,
+  Platform,
   render,
 };

--- a/src/utils/platform.js
+++ b/src/utils/platform.js
@@ -1,0 +1,6 @@
+const Platform = {
+  OS: 'word',
+  select: obj => ('word' in obj ? obj.word : obj.default),
+};
+
+export default Platform;


### PR DESCRIPTION
I added the Platform API to be consistent with React Native. A lot of other custom renderers (react-sketchapp, Apple TV, macOS, etc) all have it. It's useful for platform differences within universal components. 😀 

Feel free to change the platform name `word` to whatever you'd prefer.