### PR TITLE
fix: invalid removeChild(), use .splice instead of .slice

### DIFF
--- a/src/components/Bullet.js
+++ b/src/components/Bullet.js
@@ -18,7 +18,7 @@ class BulletItem extends Root {
 
   removeChild(child) {
     const index = this.children.indexOf(child);
-    this.children.slice(index, 1);
+    this.children.splice(index, 1);
   }
 
   async renderChildren(align, styles) {

--- a/src/components/Document.js
+++ b/src/components/Document.js
@@ -30,7 +30,7 @@ class Document {
 
   removeChild(child) {
     const index = this.children.indexOf(child);
-    this.children.slice(index, 1);
+    this.children.splice(index, 1);
   }
 
   async renderChildren() {

--- a/src/components/HOC.js
+++ b/src/components/HOC.js
@@ -21,7 +21,7 @@ function hoc(component, fn) {
 
     removeChild(child) {
       const index = this.children.indexOf(child);
-      this.children.slice(index, 1);
+      this.children.splice(index, 1);
     }
 
     async renderChildren(align, styles) {

--- a/src/components/List.js
+++ b/src/components/List.js
@@ -15,7 +15,7 @@ class List {
 
   removeChild(child) {
     const index = this.children.indexOf(child);
-    this.children.slice(index, 1);
+    this.children.splice(index, 1);
   }
 
   async renderChildren(align, styles) {

--- a/src/components/Number.js
+++ b/src/components/Number.js
@@ -18,7 +18,7 @@ class NumberItem extends Root {
 
   removeChild(child) {
     const index = this.children.indexOf(child);
-    this.children.slice(index, 1);
+    this.children.splice(index, 1);
   }
 
   async renderChildren(align, styles) {

--- a/src/components/Root.js
+++ b/src/components/Root.js
@@ -19,7 +19,7 @@ class Root {
     const index = this.children.indexOf(child);
 
     child.parent = null;
-    this.children.slice(index, 1);
+    this.children.splice(index, 1);
   }
 
   async renderChildren() {

--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -24,7 +24,7 @@ class Text extends Root {
 
   removeChild(child) {
     const index = this.children.indexOf(child);
-    this.children.slice(index, 1);
+    this.children.splice(index, 1);
   }
 
   setParent = (node, childName) => node.parent = (node.name === childName ? 'Text' : null);


### PR DESCRIPTION
Inside the method `removeChild()` ,  `this.children.slice(index, 1);` would not work at all.
We should instead use `.splice`.