### PR TITLE
Exclude regeneratorRuntime from compilation output

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,7 +3,7 @@
     [
       "env",
       {
-				"exclude": ["transform-regenerator"]
+        "exclude": ["transform-regenerator"]
       }
     ],
     "stage-0",

--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,12 @@
 {
-	"presets": ["env", "stage-0", "react"]
+  "presets": [
+    [
+      "env",
+      {
+				"exclude": ["transform-regenerator"]
+      }
+    ],
+    "stage-0",
+    "react"
+  ]
 }


### PR DESCRIPTION
... otherwise there's stuff like this in the library (look for `regeneratorRuntime`):

(excerpt from renderer/parse.js)

```js
'use strict';

Object.defineProperty(exports, "__esModule", {
  value: true
});
exports.testRenderer = exports.render = undefined;

var renderToFile = function () {
  var _ref = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee(element, filePath) {
    var container, node, output, stream;
    return regeneratorRuntime.wrap(function _callee$(_context) {
      while (1) {
        switch (_context.prev = _context.next) {
          case 0:
            container = (0, _createElement.createElement)('ROOT');


            (0, _renderUtils.validateElement)(element);

            (0, _renderUtils.validatePath)(filePath);

            node = _renderer.WordRenderer.createContainer(container);


            _renderer.WordRenderer.updateContainer(element, node, null);

            _context.next = 7;
            return (0, _parse2.default)(container).toBuffer();

          case 7:
            output = _context.sent;
            stream = _fs2.default.createWriteStream(filePath);
            _context.next = 11;
            return new Promise(function (resolve, reject) {
              output.doc.generate(stream, (0, _renderUtils.Events)(filePath, resolve, reject));

              (0, _renderUtils.openDocApp)(filePath);
            });

          case 11:
          case 'end':
            return _context.stop();
        }
      }
    }, _callee, this);
  }));

  ....
```

ref: https://github.com/nitin42/redocx/issues/18

This makes it problematic to use this library where babel runtime is not used.